### PR TITLE
add request rejection if the corresponding server die

### DIFF
--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -14,6 +14,7 @@ function Broker () {
   this.context = null;
   this.pendingRequestStore = new PendingRequest();
   this.socketOptions = null;
+  this.serverMode = null;
 }
 
 /**

--- a/lib/service/Server.js
+++ b/lib/service/Server.js
@@ -1,5 +1,6 @@
 var
   PendingRequest = require('../store/PendingRequest'),
+  InternalError = require('kuzzle-common-objects').Errors.internalError,
   q = require('q');
 
 /**
@@ -72,10 +73,14 @@ Server.prototype.onMessage = function (data) {
  * Triggered when the connection is closed
  */
 Server.prototype.onConnectionClose = function () {
-  console.log(`Connection with server ${this.socket.upgradeReq.connection.remoteAddress} closed.`);
+  console.log(`Connection with server ${this.socketIp} closed.`);
   this.context.serverConnectionStore.remove(this);
-  this.context.broker.resendPending(this.pendingRequestStore.getAll());
-  this.pendingRequestStore.clear();
+  var pendingRequests = this.pendingRequestStore.getAll();
+
+  Object.keys(pendingRequests).forEach((requestId) => {
+    pendingRequests[requestId].promise.reject(new InternalError(`Connection with server ${this.socketIp} closed.`));
+    this.pendingRequestStore.removeByRequestId(requestId);
+  });
 };
 
 /**
@@ -84,10 +89,14 @@ Server.prototype.onConnectionClose = function () {
  * @param {Error} error
  */
 Server.prototype.onConnectionError = function(error) {
-  console.error(`Connection with server ${this.socket.upgradeReq.connection.remoteAddress} was in error; Reason :`, error);
+  console.error(`Connection with server ${this.socketIp} was in error; Reason :`, error);
   this.context.serverConnectionStore.remove(this);
-  this.context.broker.resendPending(this.pendingRequestStore.getAll());
-  this.pendingRequestStore.clear();
+  var pendingRequests = this.pendingRequestStore.getAll();
+
+  Object.keys(pendingRequests).forEach((requestId) => {
+    pendingRequests[requestId].promise.reject(new InternalError(`Connection with server ${this.socketIp} was in error; Reason : ${error}`));
+    this.pendingRequestStore.removeByRequestId(requestId);
+  });
 };
 
 /**


### PR DESCRIPTION
Instead of replaying each request when a server die, send an error to clients.

This was to carry about sensible requests (like create documents, or other things in the persisted data layer) and let final user to implement his own logic.